### PR TITLE
Fix #8 voting system was blank name in web chat

### DIFF
--- a/src/ninjam-bot/bot.py
+++ b/src/ninjam-bot/bot.py
@@ -200,6 +200,7 @@ def ninjam_bot(Q, ninjam, irc):
             if mode == b"MSG":
                 # NOTE: skip self message
                 username = sender.split("@", 1)[0]
+                username = username if username else 'BOT' # XXX: ws.config
                 message = normalize(message.decode(ninjam.encoding, 'ignore'))
                 if __debug__:
                     Logger.debug("{} {}".format(username, ninjam.username))


### PR DESCRIPTION
Patch is dirty quick fix, it was not easy to modify web chat message
which already encoded to json strings.

So the name was hardcoded, this won't be fix in Python version.
that require program design changes. maybe issue for node.js version.
