### PR TITLE
Resolved #18 chat-server error handling

### DIFF
--- a/src/chat-server/server.ls
+++ b/src/chat-server/server.ls
@@ -13,18 +13,30 @@ server = ws.listen port, !->
 ,  do
   host: host
 
+process.on \uncaughtException, (e) !->
+  console.error "uncaughtException: #{e}"
+
 server.on \connection, (socket) !->
   socket
   .on \error, (e) !->
-    console.dir e
+    console.error e.message
   .on \message, (data) !->
-    msg = JSON.parse data
+
+    msg = try
+      JSON.parse data
+    catch
+      console.error e.message
+    return unless msg
+
     msg.time = dateformat new Date, 'yyyy/mm/dd HH:MM:ss'
 
-    console.log "\033[96m message recv \033[39m"
-    console.dir msg
+    console.log msg
 
-    chunk = JSON.stringify msg
+    chunk = try
+      JSON.stringify msg
+    catch
+      console.error e.message
+    return unless chunk
 
     server.clients.forEach (client) ->
       client?.send chunk


### PR DESCRIPTION
Now, chat-server won't down by unexpected exception.

_uncaughtException_ maybe removed in future, noted in node.js manual.
that will be future issue when node.js update changes.
